### PR TITLE
Make main_template py3 compatible

### DIFF
--- a/rules_python_zip/main_template.py
+++ b/rules_python_zip/main_template.py
@@ -81,7 +81,7 @@ def main():
 
     ast = compile(script_data, script_path, 'exec', flags=0, dont_inherit=1)
     # execute the script with a clean state (no imports or variables)
-    exec ast in clean_globals
+    exec(ast, clean_globals)
 
 
 # Environment variables that can change imports and break a pyz_binary


### PR DESCRIPTION
Tried to run these rules using python 3.7, by setting `interpreter_path=python3.7` on `pyz_binary` and then getting an error on the `exec` line. According to http://python-future.org/compatible_idioms.html#exec this should be compatible for both python 2 and 3.