### PR TITLE
Default legacy_run_behavior to false

### DIFF
--- a/pyz_image/pyz_image.bzl
+++ b/pyz_image/pyz_image.bzl
@@ -24,7 +24,7 @@ def pyz2_image(name, binary, base=BASE_PY2_CONTAINER_IMAGE, entrypoint=None, **k
         base=base,
         tars=[outtar],
         entrypoint = entrypoint,
-
+        legacy_run_behavior = False,
         **kwargs
     )
 


### PR DESCRIPTION
This makes the image runnable with bazel directly.